### PR TITLE
Make the default value of custom objects falsy

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dbutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dbutton.lua
@@ -30,7 +30,7 @@ E2VguiCore.AddDefaultPanelTable("dbutton",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dbutton", "xdb", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dbutton", "xdb", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckbox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckbox.lua
@@ -26,7 +26,7 @@ E2VguiCore.AddDefaultPanelTable("dcheckbox",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dcheckbox", "xdc", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dcheckbox", "xdc", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckboxlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckboxlabel.lua
@@ -28,7 +28,7 @@ E2VguiCore.AddDefaultPanelTable("dcheckboxlabel",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dcheckboxlabel", "xbl", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dcheckboxlabel", "xbl", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcolormixer.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcolormixer.lua
@@ -30,7 +30,7 @@ E2VguiCore.AddDefaultPanelTable("dcolormixer",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dcolormixer", "xde", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dcolormixer", "xde", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcombobox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcombobox.lua
@@ -30,7 +30,7 @@ E2VguiCore.AddDefaultPanelTable("dcombobox",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dcombobox", "xcb", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dcombobox", "xcb", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/defaultdermafunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/defaultdermafunctions.lua
@@ -53,6 +53,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local posX = op2[1](self,op2)
             local posY = op3[1](self,op3)
 
+            if not panel then return end -- may be nil
+
             E2VguiCore.registerAttributeChange(panel,"posX", posX)
             E2VguiCore.registerAttributeChange(panel,"posY", posY)
         end
@@ -66,6 +68,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local pos = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.registerAttributeChange(panel,"posX", pos[1])
             E2VguiCore.registerAttributeChange(panel,"posY", pos[2])
@@ -83,8 +87,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local ply = op2[1](self,op2)
 
             return {
-                E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"posX") or 0,
-                E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"posY") or 0
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"posX") or 0,
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"posY") or 0
             }
         end
         ,5)
@@ -100,6 +104,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local width = op2[1](self,op2)
             local height = op3[1](self,op3)
 
+            if not panel then return end -- may be nil
+
             E2VguiCore.registerAttributeChange(panel,"width", width)
             E2VguiCore.registerAttributeChange(panel,"height", height)
         end
@@ -113,6 +119,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local size = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.registerAttributeChange(panel,"width", size[1])
             E2VguiCore.registerAttributeChange(panel,"height", size[2])
@@ -128,8 +136,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local ply = op2[1](self,op2)
 
             return {
-                E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"width") or 0,
-                E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"height") or 0
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"width") or 0,
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"height") or 0
             }
         end
         ,5)
@@ -142,6 +150,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local width = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.registerAttributeChange(panel,"width", width)
         end
@@ -156,7 +166,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"width") or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"width") or 0
         end
         ,5)
 
@@ -168,6 +178,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local height = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.registerAttributeChange(panel,"height", height)
         end
@@ -182,7 +194,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"height") or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"height") or 0
         end
         ,5)
 
@@ -194,6 +206,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local vis = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.registerAttributeChange(panel,"visible", vis > 0)
         end
@@ -207,7 +221,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"visible") and 1 or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"visible") and 1 or 0
         end
         ,5)
 
@@ -220,6 +234,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local vis = op2[1](self,op2)
             local ply = op3[1](self,op3)
+
+            if not panel then return end -- may be nil
 
             if IsValid(ply) and ply:IsPlayer() then
                 E2VguiCore.registerAttributeChange(panel,"visible", vis > 0)
@@ -237,6 +253,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local dock = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.registerAttributeChange(panel,"dock", dock)
         end
@@ -256,6 +274,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local marginRight   = op4[1](self,op4)
             local marginBottom  = op5[1](self,op5)
 
+            if not panel then return end -- may be nil
+
             E2VguiCore.registerAttributeChange(panel,"dockMargin", {marginLeft,marginTop,marginRight,marginBottom})
         end
         ,5)
@@ -274,6 +294,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local paddingRight   = op4[1](self,op4)
             local paddingBottom  = op5[1](self,op5)
 
+            if not panel then return end -- may be nil
+
             E2VguiCore.registerAttributeChange(panel,"dockPadding", {paddingLeft,paddingTop,paddingRight,paddingBottom})
         end
         ,5)
@@ -283,6 +305,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
         registerFunction( "create", id..":", "", function(self,args)
             local op1 = args[2]
             local panel = op1[1](self,op1)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.CreatePanel(self,panel)
         end
@@ -297,6 +321,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local players = op2[1](self,op2)
 
+            if not panel then return end -- may be nil
+
             E2VguiCore.CreatePanel(self,panel,players)
         end
         ,5)
@@ -306,6 +332,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
         registerFunction( "modify", id..":", "", function(self,args)
             local op1 = args[2]
             local panel = op1[1](self,op1)
+
+            if not panel then return end -- may be nil
 
             E2VguiCore.ModifyPanel(self.player, self.entity, panel)
         end
@@ -320,6 +348,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local players = op2[1](self,op2)
 
+            if not panel then return end -- may be nil
+
             E2VguiCore.ModifyPanel(self.player, self.entity, panel, players)
         end
         ,5)
@@ -333,6 +363,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
+            if not panel then return end -- may be nil
+
             if IsValid(ply) and ply:IsPlayer() then
                 E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
             end
@@ -344,6 +376,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
         registerFunction( "closeAll", id..":", "", function(self,args)
             local op1 = args[2]
             local panel = op1[1](self,op1)
+
+            if not panel then return end -- may be nil
 
             for _,ply in pairs(panel["players"]) do
                 E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
@@ -359,6 +393,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             if IsValid(ply) and ply:IsPlayer() then
                 --check for redundant players will be done in CreatePanel or ModifyPanel
@@ -376,6 +412,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
+
+            if not panel then return end -- may be nil
 
             if IsValid(ply) and ply:IsPlayer() then
                 for k,v in pairs(panel["players"]) do
@@ -397,6 +435,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
+            if not panel then return end -- may be nil
+
             if IsValid(ply) and ply:IsPlayer() then
                 for key,pnlPly in pairs(panel["players"]) do
                     if pnlPly == ply then
@@ -414,6 +454,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local op1 = args[2]
             local panel = op1[1](self,op1)
 
+            if not panel then return end -- may be nil
+
             for _,ply in pairs(panel["players"]) do
                 E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
             end
@@ -426,7 +468,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
         registerFunction( "getPlayers", id..":", "r", function(self,args)
             local op1 = args[2]
             local panel = op1[1](self,op1)
-            return panel.players
+            return panel and panel.players or {}
         end
         ,5)
 
@@ -436,6 +478,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local op2 = args[3]
             local panel = op1[1](self,op1)
             local players = op2[1](self,op2)
+            if not panel then return end -- may be nil
             panel.players = players --gets filtered inside CreatePanel() or ModifyPanel()
         end
         ,5)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dframe.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dframe.lua
@@ -36,7 +36,7 @@ end)
 
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dframe", "xdf", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dframe", "xdf", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dimagebutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dimagebutton.lua
@@ -33,7 +33,7 @@ E2VguiCore.AddDefaultPanelTable("dimagebutton",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dimagebutton", "xib", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dimagebutton", "xib", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlabel.lua
@@ -29,7 +29,7 @@ E2VguiCore.AddDefaultPanelTable("dlabel",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dlabel", "xdl", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dlabel", "xdl", nil,
 	nil,
 	nil,
 	function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
@@ -27,7 +27,7 @@ E2VguiCore.AddDefaultPanelTable("dlistview",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dlistview", "xdv", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dlistview", "xdv", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dmodelpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dmodelpanel.lua
@@ -33,7 +33,7 @@ end)
 
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dmodelpanel", "xdk", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dmodelpanel", "xdk", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpanel.lua
@@ -31,7 +31,7 @@ end)
 
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dpanel", "xdp", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dpanel", "xdp", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
@@ -28,7 +28,7 @@ E2VguiCore.AddDefaultPanelTable("dpropertysheet",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dpropertysheet", "xdo", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dpropertysheet", "xdo", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dslider.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dslider.lua
@@ -34,7 +34,7 @@ end)
 
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dslider", "xds", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dslider", "xds", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dspawnicon.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dspawnicon.lua
@@ -25,7 +25,7 @@ E2VguiCore.AddDefaultPanelTable("dspawnicon",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dspawnicon", "xdi", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dspawnicon", "xdi", nil,
     nil,
     nil,
     function(retval)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
@@ -26,7 +26,7 @@ E2VguiCore.AddDefaultPanelTable("dtextentry",function(uniqueID,parentPnlID)
 end)
 --6th argument type checker without return,
 --7th arguement type checker with return. False for valid type and True for invalid
-registerType("dtextentry", "xdt", {["players"] = {}, ["paneldata"] = {},["changes"] = {}},
+registerType("dtextentry", "xdt", nil,
     nil,
     nil,
     function(retval)


### PR DESCRIPTION
The default value used to be something that always passed the truthiness check, due to it having a perfectly valid table structure, so you could not check for an uninitialized frame using `if (Frame) { ... }`.

```
@name
@inputs
@outputs
@persist Frame:dframe
@trigger

if (!Frame) {
	# Initialize frame...
	# Wait, oops! This never executed
}
```