### PR TITLE
Add :isValid function to all custom objects

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dbutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dbutton.lua
@@ -143,4 +143,5 @@ E2Helper.Descriptions["remove(xdb:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdb:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdb:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdb:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdb:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckbox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckbox.lua
@@ -80,3 +80,4 @@ E2Helper.Descriptions["remove(xdc:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdc:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdc:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdc:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdc:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckboxlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckboxlabel.lua
@@ -86,3 +86,4 @@ E2Helper.Descriptions["remove(xbl:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xbl:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xbl:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xbl:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xbl:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcolormixer.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcolormixer.lua
@@ -111,4 +111,5 @@ E2Helper.Descriptions["remove(xde:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xde:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xde:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xde:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xde:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcombobox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcombobox.lua
@@ -100,3 +100,4 @@ E2Helper.Descriptions["remove(xcb:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xcb:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xcb:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xcb:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xcb:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dframe.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dframe.lua
@@ -132,3 +132,4 @@ E2Helper.Descriptions["remove(xdf:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdf:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdf:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdf:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdf:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dimagebutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dimagebutton.lua
@@ -147,4 +147,5 @@ E2Helper.Descriptions["remove(xib:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xib:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xib:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xib:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xib:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlabel.lua
@@ -82,4 +82,5 @@ E2Helper.Descriptions["remove(xdl:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdl:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdl:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdl:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdl:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlistview.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlistview.lua
@@ -113,4 +113,5 @@ E2Helper.Descriptions["remove(xdv:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdv:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdv:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdv:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdv:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dmodelpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dmodelpanel.lua
@@ -129,4 +129,5 @@ E2Helper.Descriptions["remove(xdk:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdk:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdk:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdk:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdk:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpanel.lua
@@ -97,4 +97,5 @@ E2Helper.Descriptions["remove(xdp:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdp:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdp:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdp:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdp:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpropertysheet.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpropertysheet.lua
@@ -78,4 +78,5 @@ E2Helper.Descriptions["remove(xdo:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdo:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdo:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdo:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdo:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dslider.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dslider.lua
@@ -120,3 +120,4 @@ E2Helper.Descriptions["remove(xds:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xds:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xds:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xds:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xds:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dspawnIcon.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dspawnIcon.lua
@@ -83,3 +83,4 @@ E2Helper.Descriptions["remove(xdi:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdi:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdi:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdi:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdi:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dtextentry.lua
@@ -108,3 +108,4 @@ E2Helper.Descriptions["remove(xdt:e)"] = "Removes this element only on the speci
 E2Helper.Descriptions["removeAll(xdt:)"] = "Removes this element from all players in the player list and clears the element's player list."
 E2Helper.Descriptions["getPlayers(xdt:)"] = "Retrieve the current player list of this element."
 E2Helper.Descriptions["setPlayers(xdt:r)"] = "Sets the player list for this element."
+E2Helper.Descriptions["isValid(xdt:)"] = "Returns whether or not the element is valid. Elements that were not created by the element's constructor, such as persist variables that have not been assigned to, and table lookups that are not present, are not valid and do not perform any action when modified."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/defaultdermafunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/defaultdermafunctions.lua
@@ -440,5 +440,13 @@ E2VguiCore.registerCallback("loaded_elements",function()
         end
         ,5)
 
+        --add isValid() function for every panel
+        registerFunction( "isValid", id..":", "n", function(self,args)
+            local op1 = args[2]
+            local panel = op1[1](self,op1)
+            return panel and 1 or 0
+        end
+        ,5)
+
     end
 end)


### PR DESCRIPTION
NOTE: This PR depends on #11, and will always return 1 until it is merged

---

Since all methods are a no-op when objects are invalid, it's nice to
have a method that allows an E2 to query whether or not an object is
valid, for example when retrieving it from a table or a persist
variable.

The new method's documentation is as follows:

"Returns whether or not the element is valid. Elements that were not
created by the element's constructor, such as persist variables that
have not been assigned to, and table lookups that are not present, are
not valid and do not perform any action when modified."

Example code that was used to verify the method's functionality is as
follows:

```
@name
@inputs
@outputs
@persist Frame:dframe
@trigger

function void log(String: string) {
	print(_HUD_PRINTTALK, String)
}

function void logValidity(Frame: dframe) {
	Truthy = 0
	if (Frame) { Truthy = 1 }

	log("truthy: " + toString(Truthy) + ", valid: " + toString(Frame:isValid()))
}

log("Uninitialized persist (should be 0):")
logValidity(Frame)

log("Uninitialized table field (should also be 0):")
logValidity(table()["Frame",dframe])

log("Constructor function (should be 1):")
logValidity(dframe(0))
```