### PR TITLE
Add xdt:setNumeric(n) and xdt:getNumeric(e)

### DIFF
--- a/lua/autorun/client/cl_vgui_lib.lua
+++ b/lua/autorun/client/cl_vgui_lib.lua
@@ -127,7 +127,8 @@ E2VguiLib = {
         image = function(panel, value) panel:SetImage(value) end,
         keepAspect = function(panel, value) panel:SetKeepAspect(value) end,
         stretchToFit = function(panel, value) panel:SetStretchToFit(value) end,
-        sizeToContents = function(panel, value) panel:SizeToContents() end
+        sizeToContents = function(panel, value) panel:SizeToContents() end,
+        numeric = function(panel, value) panel:SetNumeric(value) end
     }
 }
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dtextentry.lua
@@ -79,6 +79,9 @@ E2Helper.Descriptions["dtextentry(nn)"] = "Creates a new textentry with the give
 E2Helper.Descriptions["setText(xdt:s)"] = "Sets the text of the textentry."
 E2Helper.Descriptions["getText(xdt:e)"] = "Returns the text of the textentry."
 
+E2Helper.Descriptions["setNumeric(xdt:n)"] = "Sets whether the TextEntry is numeric or not. If the TextEntry is numeric, then the user will not be able to type anything except the following characters: 1234567890.-"
+E2Helper.Descriptions["getNumeric(xdt:e)"] = "Returns whether the TextEntry is numeric."
+
 --default functions
 E2Helper.Descriptions["setPos(xdt:nn)"] = "Sets the position."
 E2Helper.Descriptions["setPos(xdt:xv2)"] = "Sets the position."

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
@@ -141,17 +141,7 @@ do--[[setter]]--
     e2function void dtextentry:setText(string text)
         E2VguiCore.registerAttributeChange(this,"text", text)
     end
--- setter
-end
 
-do--[[getter]]--
-    e2function string dtextentry:getText(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text") or ""
-    end
--- getter
-end
-
-do--[[setter]]--
     e2function void dtextentry:setNumeric(number numeric)
         E2VguiCore.registerAttributeChange(this,"numeric", numeric)
     end
@@ -159,6 +149,10 @@ do--[[setter]]--
 end
 
 do--[[getter]]--
+    e2function string dtextentry:getText(entity ply)
+        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text") or ""
+    end
+
     e2function number dtextentry:getNumeric(entity ply)
         return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"numeric") and 1 or 0
     end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
@@ -150,3 +150,17 @@ do--[[getter]]--
     end
 -- getter
 end
+
+do--[[setter]]--
+    e2function void dtextentry:setNumeric(number numeric)
+        E2VguiCore.registerAttributeChange(this,"numeric", numeric)
+    end
+-- setter
+end
+
+do--[[getter]]--
+    e2function number dtextentry:getNumeric(entity ply)
+        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"numeric") and 1 or 0
+    end
+-- getter
+end


### PR DESCRIPTION
Allows e2 to set dtextentry objects to be numeric, preventing users from typing non-numeric characters into it. Perfect if you're trying to create a numeric input to go alongside a slider.