### PR TITLE
E2 Reload bug

### DIFF
--- a/lua/autorun/client/cl_e2_vgui_netmessage.lua
+++ b/lua/autorun/client/cl_e2_vgui_netmessage.lua
@@ -17,20 +17,19 @@ net.Receive("E2Vgui.CreatePanel",function()
     local createSuccessful = false
     local pnlType = net.ReadString()
     local uniqueID = net.ReadInt(32)
-    local e2EntityID = net.ReadInt(32)
+    local e2_vgui_core_session_id = net.ReadInt(32)
     local pnlData = net.ReadTable()
     local changes = net.ReadTable()
     if E2VguiPanels["vgui_elements"]["functions"][pnlType] != nil and E2VguiPanels["vgui_elements"]["functions"][pnlType]["createFunc"] != nil then
-
-        if E2VguiPanels["panels"][e2EntityID] == nil then
-            E2VguiPanels["panels"][e2EntityID] = {}
+        if E2VguiPanels["panels"][e2_vgui_core_session_id] == nil then
+            E2VguiPanels["panels"][e2_vgui_core_session_id] = {}
         end
 
-        if E2VguiPanels["panels"][e2EntityID][uniqueID] == nil then
+        if E2VguiPanels["panels"][e2_vgui_core_session_id][uniqueID] == nil then
             local panelParentID = pnlData["parentID"]
-            if panelParentID == nil or (panelParentID != nil and E2VguiPanels["panels"][e2EntityID][panelParentID]) then
+            if panelParentID == nil or (panelParentID != nil and E2VguiPanels["panels"][e2_vgui_core_session_id][panelParentID]) then
                 local createFunc = E2VguiPanels["vgui_elements"]["functions"][pnlType]["createFunc"]
-                createSuccessful = createFunc(uniqueID,pnlData,e2EntityID,changes)
+                createSuccessful = createFunc(uniqueID,pnlData,e2_vgui_core_session_id,changes)
             end
         else
             --panel already exists. How to deal that on serverside ? maybe overwrite/modify it ?
@@ -40,7 +39,7 @@ net.Receive("E2Vgui.CreatePanel",function()
 
     net.Start("E2Vgui.ConfirmCreation")
         net.WriteInt(uniqueID,32)
-        net.WriteInt(e2EntityID,32)
+        net.WriteInt(e2_vgui_core_session_id,32)
         net.WriteBool(createSuccessful)
         net.WriteTable(pnlData)
     net.SendToServer()
@@ -53,17 +52,17 @@ net.Receive("E2Vgui.ModifyPanel",function()
     local createSuccessful = nil
     local pnlType = net.ReadString()
     local uniqueID = net.ReadInt(32)
-    local e2EntityID = net.ReadInt(32)
+    local e2_vgui_core_session_id = net.ReadInt(32)
     local changes = net.ReadTable()
 
     local pnlData = {}
     if E2VguiPanels["vgui_elements"]["functions"][pnlType] != nil and E2VguiPanels["vgui_elements"]["functions"][pnlType]["modifyFunc"] != nil then
 
-        if E2VguiPanels["panels"][e2EntityID] != nil and E2VguiPanels["panels"][e2EntityID][uniqueID] != nil then
-            pnlData = E2VguiPanels["panels"][e2EntityID][uniqueID]["pnlData"]
+        if E2VguiPanels["panels"][e2_vgui_core_session_id] != nil and E2VguiPanels["panels"][e2_vgui_core_session_id][uniqueID] != nil then
+            pnlData = E2VguiPanels["panels"][e2_vgui_core_session_id][uniqueID]["pnlData"]
 
             local modifyFunc = E2VguiPanels["vgui_elements"]["functions"][pnlType]["modifyFunc"]
-            modifiedSuccess = modifyFunc(uniqueID,e2EntityID,changes)
+            modifiedSuccess = modifyFunc(uniqueID,e2_vgui_core_session_id,changes)
 --[[ Don't recreate the panel when the player closed it
         elseif not ["panels"][e2EntityID][uniqueID] then
             local createFunc = E2VguiPanels["vgui_elements"]["functions"][pnlType]["createFunc"]
@@ -75,7 +74,7 @@ net.Receive("E2Vgui.ModifyPanel",function()
     if modifiedSuccess ~= nil then
         net.Start("E2Vgui.ConfirmModification")
             net.WriteInt(uniqueID,32)
-            net.WriteInt(e2EntityID,32)
+            net.WriteInt(e2_vgui_core_session_id,32)
             net.WriteBool(modifiedSuccess)
             net.WriteTable(pnlData)
         net.SendToServer()

--- a/lua/autorun/client/cl_e2_vgui_netmessage.lua
+++ b/lua/autorun/client/cl_e2_vgui_netmessage.lua
@@ -95,6 +95,7 @@ net.Receive("E2Vgui.ClosePanels",function()
             pnl:Remove()
             E2VguiPanels["panels"][e2Index][id] = nil
         end
+        E2VguiPanels["panels"][e2Index] = nil
     elseif mode == 0 then
         local e2Index = net.ReadInt(32)
         local panelsIDs = net.ReadTable()

--- a/lua/autorun/client/cl_vgui_lib.lua
+++ b/lua/autorun/client/cl_vgui_lib.lua
@@ -29,7 +29,7 @@ E2VguiLib = {
         deleteOnClose = function(panel,value) panel:SetDeleteOnClose(value) end,
         makepopup = function(panel,value) if value == true then panel:MakePopup() end end,
         mouseinput = function(panel,value) panel:SetMouseInputEnabled(value) end,
-        keyboardinput = function(panel,value) panel:SetKeyBoardInputEnabled(value) end,
+        keyboardinput = function(panel,value) panel:SetKeyboardInputEnabled(value) end,
         showCloseButton = function(panel,value) panel:ShowCloseButton(value) end,
         dark = function(panel,value) panel:SetDark(value) end,
         decimals = function(panel,value) panel:SetDecimals(value) end,

--- a/lua/autorun/client/cl_vgui_lib.lua
+++ b/lua/autorun/client/cl_vgui_lib.lua
@@ -69,7 +69,7 @@ E2VguiLib = {
         textwrap = function(panel,value) panel:SetWrap(value) end,
         autoStrechVertical = function(panel,value) panel:SetAutoStretchVertical(value) end,
         addsheet = function(panel,values)
-            local sheet_pnl = E2VguiLib.GetPanelByID(values["panelID"],values["e2EntityID"])
+            local sheet_pnl = E2VguiLib.GetPanelByID(values["panelID"],values["e2_vgui_core_session_id"])
             if(not ispanel(sheet_pnl)) then return end
             if values["icon"] == "" then values["icon"] = nil end
             panel:AddSheet(values["name"],sheet_pnl,values["icon"])
@@ -142,18 +142,18 @@ E2VguiLib = {
 
 
 --used to register a new created panel
-function E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, pnl)
-    E2VguiPanels.panels[e2EntityID][uniqueID] = pnl
-    pnl["pnlData"]["e2EntityID"] = e2EntityID
+function E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, pnl)
+    E2VguiPanels.panels[e2_vgui_core_session_id][uniqueID] = pnl
+    pnl["pnlData"]["e2_vgui_core_session_id"] = e2_vgui_core_session_id
     --  TODO:Add hooks later ?
     --  hook.Run("E2VguiLib.RegisterNewPanel",LocalPlayer(),e2EntityID,pnl)
 end
 
 
 --function to retrieve a panel of a specified e2
-function E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
-    if E2VguiPanels["panels"][e2EntityID] == nil then return end
-    local pnl = E2VguiPanels["panels"][e2EntityID][uniqueID]
+function E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
+    if E2VguiPanels["panels"][e2_vgui_core_session_id] == nil then return end
+    local pnl = E2VguiPanels["panels"][e2_vgui_core_session_id][uniqueID]
     return pnl
 end
 
@@ -185,9 +185,9 @@ function E2VguiLib.applyAttributes(panel,attributes,otherFormat)
 end
 
 --this updates the pos and size values of the panel that is stored on the server
-function E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+function E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     net.Start("E2Vgui.UpdateServerValues")
-    net.WriteInt(e2EntityID,32)
+    net.WriteInt(e2_vgui_core_session_id,32)
     net.WriteInt(uniqueID,32)
     local posX,posY = panel:GetPos()
     local width,height = panel:GetSize()
@@ -202,9 +202,9 @@ end
 
 
 --Maybe optimise this by creating a 'children' table for each panel ?
-function E2VguiLib.GetChildPanelIDs(uniqueID,e2EntityID,pnlList)
+function E2VguiLib.GetChildPanelIDs(uniqueID,e2_vgui_core_session_id,pnlList)
     local tbl = pnlList or {[uniqueID] = true}
-    local pnl = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+    local pnl = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if pnl != nil and pnl:HasChildren() then
         for k,v in pairs(pnl:GetChildren()) do
             --Add the ID to the list
@@ -216,7 +216,7 @@ function E2VguiLib.GetChildPanelIDs(uniqueID,e2EntityID,pnlList)
 
             --if the pnl has childs get their child panels as well
             if v:HasChildren() then
-                local panels = E2VguiLib.GetChildPanelIDs(v.uniqueID,e2EntityID,tbl)
+                local panels = E2VguiLib.GetChildPanelIDs(v.uniqueID,e2_vgui_core_session_id,tbl)
                 table.Merge(tbl, panels)
             end
         end
@@ -347,14 +347,14 @@ end
 
 --used to remove the panel clientside and automatically informs the server
 --e.g. when you close a Dframe with the close button
-function E2VguiLib.RemovePanelWithChilds(panel,e2EntityID)
+function E2VguiLib.RemovePanelWithChilds(panel,e2_vgui_core_session_id)
     local uniqueID = panel["uniqueID"]
-    local panels = E2VguiLib.GetChildPanelIDs(uniqueID,e2EntityID)
+    local panels = E2VguiLib.GetChildPanelIDs(uniqueID,e2_vgui_core_session_id)
 
     for k,v in pairs(panels) do
         --remove the panel on clientside table
-        if E2VguiPanels["panels"][e2EntityID] ~= nil then
-            E2VguiPanels["panels"][e2EntityID][v] = nil
+        if E2VguiPanels["panels"][e2_vgui_core_session_id] ~= nil then
+            E2VguiPanels["panels"][e2_vgui_core_session_id][v] = nil
         end
     end
 
@@ -362,7 +362,7 @@ function E2VguiLib.RemovePanelWithChilds(panel,e2EntityID)
     net.Start("E2Vgui.NotifyPanelRemove")
         -- -2 : none -1: single / 0 : multiple / 1 : all
         net.WriteInt(0,3)
-        net.WriteInt(e2EntityID,32)
+        net.WriteInt(e2_vgui_core_session_id,32)
         net.WriteTable(panels)
     net.SendToServer()
 end

--- a/lua/autorun/server/vguiCore.lua
+++ b/lua/autorun/server/vguiCore.lua
@@ -7,7 +7,7 @@ E2VguiCore = {
     ["Buddies"] = {},
     ["BlockedPlayers"] = {},
     ["LinkedVehicles"] = {},
-    ["callbacks"] = {}    
+    ["sessionIDToE2Entity"] = {}
 }
 
 util.AddNetworkString("E2Vgui.CreatePanel")
@@ -307,7 +307,7 @@ function E2VguiCore.CreatePanel(e2self, panel, players)
     if table.Count(panel.paneldata) == 0 then return end
 
 
-    local e2EntityID = e2self.entity.e2_vgui_core_session_id
+    local e2_vgui_core_session_id = e2self.entity.e2_vgui_core_session_id
     local players = players or panel["players"]
     local paneldata = panel["paneldata"]
     local changes = panel["changes"]
@@ -341,21 +341,21 @@ function E2VguiCore.CreatePanel(e2self, panel, players)
     local notCreatedYet = {}
     --update server table with new values
     for k,ply in pairs(players) do
-        if ply.e2_vgui_core == nil or ply.e2_vgui_core[e2EntityID] == nil
-            or ply.e2_vgui_core[e2EntityID][uniqueID] == nil then
+        if ply.e2_vgui_core == nil or ply.e2_vgui_core[e2_vgui_core_session_id] == nil
+            or ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] == nil then
             notCreatedYet[#notCreatedYet+1] = ply
         end
         ply.e2_vgui_core = ply.e2_vgui_core or {}
-        ply.e2_vgui_core[e2EntityID] = ply.e2_vgui_core[e2EntityID] or {}
+        ply.e2_vgui_core[e2_vgui_core_session_id] = ply.e2_vgui_core[e2_vgui_core_session_id] or {}
         --table.copy here because otherwise it sets the same table for every player
         -- but we want every player to have a individual table
-        ply.e2_vgui_core[e2EntityID][uniqueID] = table.Copy(panel)
+        ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] = table.Copy(panel)
     end
 
     net.Start("E2Vgui.CreatePanel")
         net.WriteString(pnlType)
         net.WriteInt(uniqueID,32)
-        net.WriteInt(e2EntityID,32)
+        net.WriteInt(e2_vgui_core_session_id,32)
         net.WriteTable(paneldata)
         net.WriteTable(changes)
     net.Send(notCreatedYet)
@@ -380,7 +380,7 @@ function E2VguiCore.ModifyPanel(e2Owner, e2Entity, panel, players, updateChildsT
     if #panel.players == 0 and players == nil then return end
     if table.Count(panel.paneldata) == 0 then return end
 
-    local e2EntityID = e2Entity.e2_vgui_core_session_id
+    local e2_vgui_core_session_id = e2Entity.e2_vgui_core_session_id
     local players = players or panel["players"]
     local paneldata = panel["paneldata"]
     local changes = panel["changes"]
@@ -425,17 +425,17 @@ function E2VguiCore.ModifyPanel(e2Owner, e2Entity, panel, players, updateChildsT
     --update server table with new values
     for k,ply in pairs(players) do
         if ply.e2_vgui_core == nil then continue end --the player closed the panel already, no need to update
-        if ply.e2_vgui_core[e2EntityID] == nil then continue end
+        if ply.e2_vgui_core[e2_vgui_core_session_id] == nil then continue end
         --table.copy here because otherwise it sets the same table for every player
         -- but we want every player to have a individual table
-        ply.e2_vgui_core[e2EntityID][uniqueID] = table.Copy(panel)
+        ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] = table.Copy(panel)
         table.insert(stillOpen,ply)
     end
 
     net.Start("E2Vgui.ModifyPanel")
         net.WriteString(pnlType)
         net.WriteInt(uniqueID,32)
-        net.WriteInt(e2EntityID,32)
+        net.WriteInt(e2_vgui_core_session_id,32)
         net.WriteTable(changes)
     net.Send(stillOpen)
 
@@ -625,16 +625,16 @@ end
 Desc:   Returns a panel table
 Args:
     ply:    the player you want to get the panel from
-    e2e2EntityID: the entity id of the e2 the panel belongs to
+    e2_vgui_core_session_id: session index
     uniqueID: the uniqueID of the panel
 Return: <>
 ---------------------------------------------------------------------------]]
-function E2VguiCore.GetPanelByID(ply,e2EntityID, uniqueID)
+function E2VguiCore.GetPanelByID(ply,e2_vgui_core_session_id, uniqueID)
     if ply == nil or not ply:IsPlayer() then return end
     if ply.e2_vgui_core == nil then return end
-    if ply.e2_vgui_core[e2EntityID] == nil then return  end
-    if ply.e2_vgui_core[e2EntityID][uniqueID] == nil then return end
-    return ply.e2_vgui_core[e2EntityID][uniqueID]
+    if ply.e2_vgui_core[e2_vgui_core_session_id] == nil then return  end
+    if ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] == nil then return end
+    return ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID]
 end
 
 --[[-------------------------------------------------------------------------
@@ -642,13 +642,13 @@ end
 Desc:   tries to retrieve the value of a attribute from a panel
 Args:
     ply:    the player to which the panel belongs
-    e2EntityID: the entity id of the e2 the panel belongs to
+    e2_vgui_core_session_id: session index
 Return: the attribute value or nil
 ---------------------------------------------------------------------------]]
-function E2VguiCore.GetPanelAttribute(ply,e2EntityID,pnlVar,attributeName)
+function E2VguiCore.GetPanelAttribute(ply,e2_vgui_core_session_id,pnlVar,attributeName)
     if not E2VguiCore.IsPanelInitialised(pnlVar) then return nil end
 
-    local pnl = E2VguiCore.GetPanelByID(ply,e2EntityID, pnlVar["paneldata"]["uniqueID"])
+    local pnl = E2VguiCore.GetPanelByID(ply,e2_vgui_core_session_id, pnlVar["paneldata"]["uniqueID"])
     if pnl != nil then
         return pnl["paneldata"][attributeName]
     end
@@ -812,7 +812,6 @@ function E2VguiCore.linkToVehicle(e2self, panel, vehicle)
     }
 end
 
--- TODO: Call in "destruct" event
 function E2VguiCore.removeLinkFromVehicle(e2self, panel)
     if e2self == nil then return end
     if panel == nil then return end
@@ -871,20 +870,20 @@ end
                 E2VguiCore.RemovePanelOnPlayerServer
 Desc: This is used to remove panels from the serverside if they fail to create on a client (Check net.Receive("E2Vgui.ConfirmCreation",...) )
 Args:
-    e2EntityID: index of e2 entity
+    e2_vgui_core_session_id: session index
     uniqueID:   ID of the panel
     ply:        the player of the panel
 Return: nil
 ---------------------------------------------------------------------------]]
-function E2VguiCore.RemovePanelOnPlayerServer(e2EntityID,uniqueID,ply)
-    if e2EntityID == nil or uniqueID == nil or ply == nil or not ply:IsPlayer() then return end
+function E2VguiCore.RemovePanelOnPlayerServer(e2_vgui_core_session_id,uniqueID,ply)
+    if e2_vgui_core_session_id == nil or uniqueID == nil or ply == nil or not ply:IsPlayer() then return end
     if ply.e2_vgui_core == nil then return end
-    if ply.e2_vgui_core[e2EntityID] != nil then
-        if ply.e2_vgui_core[e2EntityID][uniqueID] ~= nil then
-            ply.e2_vgui_core[e2EntityID][uniqueID] = nil
+    if ply.e2_vgui_core[e2_vgui_core_session_id] != nil then
+        if ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] ~= nil then
+            ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] = nil
         end
-        if table.Count(ply.e2_vgui_core[e2EntityID]) ==  0 then
-            ply.e2_vgui_core[e2EntityID] = nil
+        if table.Count(ply.e2_vgui_core[e2_vgui_core_session_id]) ==  0 then
+            ply.e2_vgui_core[e2_vgui_core_session_id] = nil
         end
     end
 end
@@ -896,48 +895,48 @@ Desc: This is used to delete all panels on every client of a specific e2
 Args:
     e2EntityID: the e2 index
 ---------------------------------------------------------------------------]]
-function E2VguiCore.RemoveAllPanelsOfE2(e2EntityID)
-    if e2EntityID == nil then return end
+function E2VguiCore.RemoveAllPanelsOfE2(e2_vgui_core_session_id)
+    if e2_vgui_core_session_id == nil then return end
         net.Start("E2Vgui.ClosePanels")
             net.WriteInt(-1,3)
-            net.WriteInt(e2EntityID,32)
+            net.WriteInt(e2_vgui_core_session_id,32)
         net.Broadcast()
         for k,v in pairs(player.GetAll()) do
             if v.e2_vgui_core ~= nil then
-                v.e2_vgui_core[e2EntityID] = nil
+                v.e2_vgui_core[e2_vgui_core_session_id] = nil
             end
         end
 end
 
 
-function E2VguiCore.RemovePanelsOnPlayer(e2EntityID,ply)
-    if e2EntityID == nil or ply == nil or not ply:IsPlayer() then return end
-    if ply.e2_vgui_core[e2EntityID] == nil then return end
+function E2VguiCore.RemovePanelsOnPlayer(e2_vgui_core_session_id,ply)
+    if e2_vgui_core_session_id == nil or ply == nil or not ply:IsPlayer() then return end
+    if ply.e2_vgui_core[e2_vgui_core_session_id] == nil then return end
 
     local panels = {uniqueID}
     net.Start("E2Vgui.ClosePanels")
         net.WriteInt(-1,3)
-        net.WriteInt(e2EntityID,32)
+        net.WriteInt(e2_vgui_core_session_id,32)
     net.Send(ply)
 
-    ply.e2_vgui_core[e2EntityID] = nil
+    ply.e2_vgui_core[e2_vgui_core_session_id] = nil
 end
 
 
-function E2VguiCore.RemovePanel(e2EntityID,uniqueID,ply)
-    if e2EntityID == nil or uniqueID == nil or ply == nil or not ply:IsPlayer() then return end
-    if ply.e2_vgui_core[e2EntityID] == nil then return end
+function E2VguiCore.RemovePanel(e2_vgui_core_session_id,uniqueID,ply)
+    if e2_vgui_core_session_id == nil or uniqueID == nil or ply == nil or not ply:IsPlayer() then return end
+    if ply.e2_vgui_core[e2_vgui_core_session_id] == nil then return end
 
     local panels = {uniqueID}
     net.Start("E2Vgui.ClosePanels")
         net.WriteInt(0,3)
-        net.WriteInt(e2EntityID,32)
+        net.WriteInt(e2_vgui_core_session_id,32)
         net.WriteTable(panels)
     net.Send(ply)
 
-    ply.e2_vgui_core[e2EntityID][uniqueID] = nil
-    if table.Count(ply.e2_vgui_core[e2EntityID]) ==  0 then
-        ply.e2_vgui_core[e2EntityID] = nil
+    ply.e2_vgui_core[e2_vgui_core_session_id][uniqueID] = nil
+    if table.Count(ply.e2_vgui_core[e2_vgui_core_session_id]) ==  0 then
+        ply.e2_vgui_core[e2_vgui_core_session_id] = nil
     end
 end
 
@@ -962,11 +961,13 @@ E2VguiCore.registerCallback("finished_loading", function()
     -- Register callback after (re-)loading wire cores (initial loading and reloading via wire_expression2_reload)
     registerCallback("destruct", function(self)
         E2VguiCore.RemoveAllPanelsOfE2(self.entity.e2_vgui_core_session_id)
+        E2VguiCore.sessionIDToE2Entity[self.entity.e2_vgui_core_session_id] = nil
+        E2VguiCore.LinkedVehicles[self.entity:EntIndex()] = nil
+        E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] = nil
 
---TODO: Check of this is served any purpose
---         if entity:GetOwner().e2_vgui_core_default_players != nil then
---             entity:GetOwner().e2_vgui_core_default_players[entity:EntIndex()] = nil
---         end
+        if self.entity.e2_vgui_core_default_players != nil then
+            self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] = nil
+        end
     end)
     registerCallback("construct", function(self)
         -- give each e2 a random session id (was originally e2EntityID)
@@ -974,7 +975,25 @@ E2VguiCore.registerCallback("finished_loading", function()
         -- when reloading we tell all clients to remove the old panels (see e2 "destruct" callback above)
         -- and then generate a new session_id (here in the e2 "construct" event) which is used to identify panels for the reloaded e2
         -- any events from the old e2 code (panel removal/closing, button clicks, etc.) will be ignored for the new e2 session
-        self.entity.e2_vgui_core_session_id = math.floor(math.Rand(0, 1000000))
+        local e2_vgui_core_session_id = -1
+        local try = 0
+        repeat 
+            e2_vgui_core_session_id = math.floor(math.Rand(0, 1000000))
+            try = try + 1
+            -- unlikely but still better than crashing the game with an infinite loop
+            if try > 100 then
+                e2_vgui_core_session_id = -1
+                break
+            end
+        until E2VguiCore.sessionIDToE2Entity[e2_vgui_core_session_id] == nil
+
+        if e2_vgui_core_session_id == -1 then
+            error("[E2VguiCore] Unable to assign new e2_vgui_core_session_id")
+            return
+        end
+
+        self.entity.e2_vgui_core_session_id = e2_vgui_core_session_id
+        E2VguiCore.sessionIDToE2Entity[e2_vgui_core_session_id] = self.entity
     end)
 end)
 --[[-------------------------------------------------------------------------
@@ -987,17 +1006,17 @@ net.Receive("E2Vgui.NotifyPanelRemove",function(len, ply)
         return
     elseif mode == -1 then
         local uniqueID = net.ReadInt(32)
-        local e2EntityID = net.ReadInt(32)
+        local e2_vgui_core_session_id = net.ReadInt(32)
         local paneldata = net.ReadTable()
-        E2VguiCore.RemovePanelOnPlayerServer(e2EntityID,uniqueID,ply)
+        E2VguiCore.RemovePanelOnPlayerServer(e2_vgui_core_session_id,uniqueID,ply)
     elseif mode == 0 then
-        local e2EntityID = net.ReadInt(32)
+        local e2_vgui_core_session_id = net.ReadInt(32)
         local panels = net.ReadTable()
         for k,panelID in pairs(panels) do
-            local panel = E2VguiCore.GetPanelByID(ply,e2EntityID,panelID)
+            local panel = E2VguiCore.GetPanelByID(ply,e2_vgui_core_session_id,panelID)
             if panel != nil then
                 local uniqueID = panel["paneldata"]["uniqueID"]
-                E2VguiCore.RemovePanelOnPlayerServer(e2EntityID,uniqueID,ply)
+                E2VguiCore.RemovePanelOnPlayerServer(e2_vgui_core_session_id,uniqueID,ply)
             end
         end
     elseif mode == 1 then
@@ -1007,20 +1026,20 @@ end)
 
 net.Receive("E2Vgui.ConfirmCreation",function(len,ply)
     local uniqueID = net.ReadInt(32)
-    local e2EntityID = net.ReadInt(32)
+    local e2_vgui_core_session_id = net.ReadInt(32)
     local success = net.ReadBool()
     local paneldata = net.ReadTable()
     if success then
         --do nothing since we already created the panel on the server
     else
         --remove the panel from the server again since its not valid on that player
-        E2VguiCore.RemovePanelOnPlayerServer(e2EntityID,uniqueID,ply)
+        E2VguiCore.RemovePanelOnPlayerServer(e2_vgui_core_session_id,uniqueID,ply)
     end
 end)
 
 net.Receive("E2Vgui.ConfirmModification",function(len,ply)
     local uniqueID = net.ReadInt(32)
-    local e2EntityID = net.ReadInt(32)
+    local e2_vgui_core_session_id = net.ReadInt(32)
     local success = net.ReadBool()
     local paneldata = net.ReadTable()
     if success then
@@ -1098,66 +1117,70 @@ function E2VguiCore.BlockPlayers(ply, blockedPlayers)
     end
 end
 
-function E2VguiCore.UpdateServerValuesFromTable(ply,e2EntityID,uniqueID,tableData)
+function E2VguiCore.UpdateServerValuesFromTable(ply,e2_vgui_core_session_id,uniqueID,tableData)
     --Set the attribute values on the server correct
-    local pnl = E2VguiCore.GetPanelByID(ply,e2EntityID, uniqueID)
+    local pnl = E2VguiCore.GetPanelByID(ply,e2_vgui_core_session_id, uniqueID)
     if pnl == nil then return end
     for attributeName,value in pairs(tableData) do
         pnl["paneldata"][attributeName] = value
     end
 end
 
-function E2VguiCore.TriggerE2(e2EntityID,uniqueID, triggerPly, tableData)
-    if E2VguiCore.Trigger[e2EntityID] == nil then
-        E2VguiCore.Trigger[e2EntityID] = {}
+function E2VguiCore.TriggerE2(e2_vgui_core_session_id,uniqueID, triggerPly, tableData)
+    if E2VguiCore.Trigger[e2_vgui_core_session_id] == nil then
+        E2VguiCore.Trigger[e2_vgui_core_session_id] = {}
     end
 
     if triggerPly == nil or not triggerPly:IsPlayer() then return end
-    local e2Entity = ents.GetByIndex(e2EntityID)
+    local e2Entity = E2VguiCore.GetE2EntityBySessionID(e2_vgui_core_session_id)
     if not IsValid(e2Entity) then return end
     if e2Entity:GetClass() != "gmod_wire_expression2" then return end
 
     local value = value and tostring(value) or ""
 
-    E2VguiCore.UpdateServerValuesFromTable(triggerPly,e2EntityID,uniqueID,tableData)
+    E2VguiCore.UpdateServerValuesFromTable(triggerPly,e2_vgui_core_session_id,uniqueID,tableData)
     local ignoredE2s = table.Copy(E2Lib.Env.Events["vguiClk"].listening)
     -- Remove the e2 that triggered from the ignore list so we only call the event for it
     -- a E2Lib.triggerEventOnly() method would be better
-    ignoredE2s[Entity(e2EntityID)] = nil
+    ignoredE2s[e2Entity] = nil
     E2Lib.triggerEventOmit("vguiClk", { triggerPly, uniqueID, E2VguiCore.convertToE2Table(tableData) }, ignoredE2s)
 
-    if E2VguiCore.Trigger[e2EntityID].RunOnDerma ~= nil and E2VguiCore.Trigger[e2EntityID].RunOnDerma ~= false then        
-        E2VguiCore.Trigger[e2EntityID].triggeredByClient = triggerPly
-        E2VguiCore.Trigger[e2EntityID].triggerValues = E2VguiCore.convertLuaTableToArray(tableData)
-        E2VguiCore.Trigger[e2EntityID].triggerValuesTable = E2VguiCore.convertToE2Table(tableData)
-        E2VguiCore.Trigger[e2EntityID].triggerUniqueID = uniqueID
-        E2VguiCore.Trigger[e2EntityID].run = true
+    if E2VguiCore.Trigger[e2_vgui_core_session_id].RunOnDerma ~= nil and E2VguiCore.Trigger[e2_vgui_core_session_id].RunOnDerma ~= false then        
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggeredByClient = triggerPly
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggerValues = E2VguiCore.convertLuaTableToArray(tableData)
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggerValuesTable = E2VguiCore.convertToE2Table(tableData)
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggerUniqueID = uniqueID
+        E2VguiCore.Trigger[e2_vgui_core_session_id].run = true
 
         e2Entity:Execute()
 
-        E2VguiCore.Trigger[e2EntityID].triggeredByClient = NULL
-        E2VguiCore.Trigger[e2EntityID].triggerValues = {}
-        E2VguiCore.Trigger[e2EntityID].triggerValuesTable = {n={},ntypes={},s={},stypes={},size=0}
-        E2VguiCore.Trigger[e2EntityID].triggerUniqueID = -1
-        E2VguiCore.Trigger[e2EntityID].run = false
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggeredByClient = NULL
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggerValues = {}
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggerValuesTable = {n={},ntypes={},s={},stypes={},size=0}
+        E2VguiCore.Trigger[e2_vgui_core_session_id].triggerUniqueID = -1
+        E2VguiCore.Trigger[e2_vgui_core_session_id].run = false
     end
+end
+
+function E2VguiCore.GetE2EntityBySessionID(e2_vgui_core_session_id)
+    return E2VguiCore.sessionIDToE2Entity[e2_vgui_core_session_id]
 end
 
 --Only updates the server values and executes the e2
 net.Receive("E2Vgui.TriggerE2",function(len,ply)
-    local e2EntityID = net.ReadInt(32)
+    local e2_vgui_core_session_id = net.ReadInt(32)
     local uniqueID = net.ReadInt(32)
     local panelType = net.ReadString()
     local tableData = net.ReadTable()
-    E2VguiCore.TriggerE2(e2EntityID,uniqueID, ply, tableData)
+    E2VguiCore.TriggerE2(e2_vgui_core_session_id,uniqueID, ply, tableData)
 end)
 
 --Only updates the server values without executing the e2
 net.Receive("E2Vgui.UpdateServerValues",function(len,ply)
-    local e2EntityID = net.ReadInt(32)
+    local e2_vgui_core_session_id = net.ReadInt(32)
     local uniqueID = net.ReadInt(32)
     local tableData = net.ReadTable()
-    E2VguiCore.UpdateServerValuesFromTable(ply,e2EntityID,uniqueID,tableData)
+    E2VguiCore.UpdateServerValuesFromTable(ply,e2_vgui_core_session_id,uniqueID,tableData)
 end)
 
 net.Receive("E2Vgui.AddRemoveBuddy",function( len,ply )

--- a/lua/entities/gmod_wire_expression2/core/custom/load_vgui_elements.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/load_vgui_elements.lua
@@ -69,6 +69,10 @@ e2_include_init()
 -- Load serverside files here, they need additional parsing
 -- see top of this file
 E2VguiCore.registerCallback("before_loading_elements",function()
+    -- remove hooks to prevent calling them twice (this could happen if wire_expression2_reload 
+    -- is called since the hook is added in defaultdermafunctions.lua)
+    -- Do not use this hook for other purposes since they will get removed once wire_expression2_reload is called
+    -- use "finished_loading" instead
     E2VguiCore.callbacks["loaded_elements"] = {}
 end)
 
@@ -90,5 +94,6 @@ print("\\###########################################################/")
 
 e2_include_finalize()
 E2VguiCore.executeCallback("loaded_elements")
+E2VguiCore.executeCallback("finished_loading")
 --wire_expression2_CallHook("postinit")
 --wire_expression2_PostLoadExtensions()

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dbutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dbutton.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dbutton"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DButton",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,7 +8,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["createFunc"] = function(u
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
 
@@ -40,7 +40,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["createFunc"] = function(u
         if uniqueID != nil then
 --   E2VguiLib.GetPanelByID(uniqueID,e2EntityID) = nil
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("DButton")
                 net.WriteTable({
@@ -51,14 +51,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["createFunc"] = function(u
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -86,7 +86,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dbutton"]["modifyFunc"] = function(u
         return self:SetTextStyleColor( Normal )
     end
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckbox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckbox.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DCheckBox",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,14 +8,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"]["createFunc"] = function
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     function panel:OnChange(bVal)
         local uniqueID = self["uniqueID"]
         if uniqueID != nil then
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("DCheckBox")
                 net.WriteTable({
@@ -26,20 +26,20 @@ E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"]["createFunc"] = function
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcheckbox"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckboxlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcheckboxlabel.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DCheckBoxLabel",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,14 +8,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"]["createFunc"] = fun
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     function panel:OnChange(bVal)
         local uniqueID = self["uniqueID"]
         if uniqueID != nil then
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("DCheckBoxLabel")
                 net.WriteTable({
@@ -26,20 +26,20 @@ E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"]["createFunc"] = fun
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcheckboxlabel"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcolormixer.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcolormixer.lua
@@ -1,13 +1,13 @@
 E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DColorMixer",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(pnlData,data)
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
     panel["changed"] = true
 
@@ -17,7 +17,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["createFunc"] = functi
                 local uniqueID = self["uniqueID"]
                 if uniqueID != nil then
                     net.Start("E2Vgui.TriggerE2")
-                        net.WriteInt(e2EntityID,32)
+                        net.WriteInt(e2_vgui_core_session_id,32)
                         net.WriteInt(uniqueID,32)
                         net.WriteString("DColorMixer")
                         local c = self:GetColor()
@@ -38,14 +38,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["createFunc"] = functi
 
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -57,7 +57,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dcolormixer"]["modifyFunc"] = functi
             surface.DrawRect(0,0,w,h)
         end
     end
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcombobox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dcombobox.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dcombobox"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dcombobox"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcombobox"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DComboBox",parent)
     pnlData["choice"] = nil --remove it otherwise it will get added twice
     E2VguiLib.applyAttributes(panel,pnlData,true) --don't execute default table, choices will get duplicated
@@ -10,14 +10,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dcombobox"]["createFunc"] = function
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     function panel:OnSelect(index,value,data)
         local uniqueID = self["uniqueID"]
         if uniqueID != nil then
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("DComboBox")
                 net.WriteTable({
@@ -30,20 +30,20 @@ E2VguiPanels["vgui_elements"]["functions"]["dcombobox"]["createFunc"] = function
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dcombobox"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dcombobox"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dframe.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dframe.lua
@@ -1,5 +1,5 @@
 E2VguiPanels["vgui_elements"]["functions"]["dframe"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dframe"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
+E2VguiPanels["vgui_elements"]["functions"]["dframe"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
     local panel = vgui.Create("DFrame")
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -7,12 +7,12 @@ E2VguiPanels["vgui_elements"]["functions"]["dframe"]["createFunc"] = function(un
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     function panel:OnClose()
         net.Start("E2Vgui.UpdateServerValues")
-            net.WriteInt(e2EntityID,32)
+            net.WriteInt(e2_vgui_core_session_id,32)
             net.WriteInt(uniqueID,32)
             net.WriteTable({
                 visible = false
@@ -38,14 +38,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dframe"]["createFunc"] = function(un
 
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dframe"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dframe"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -66,7 +66,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dframe"]["modifyFunc"] = function(un
             draw.RoundedBoxEx(5,1,1,w-2,25-2,col2,true,true,false,false)
         end
     end
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dimagebutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dimagebutton.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DImageButton",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,7 +8,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["createFunc"] = funct
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
 
@@ -39,7 +39,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["createFunc"] = funct
         local uniqueID = self["uniqueID"]
         if uniqueID != nil then
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("DImageButton")
                 net.WriteTable({
@@ -50,14 +50,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["createFunc"] = funct
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -85,7 +85,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dimagebutton"]["modifyFunc"] = funct
         return self:SetTextStyleColor( Normal )
     end
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlabel.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dlabel"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dlabel"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dlabel"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DLabel",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,24 +8,24 @@ E2VguiPanels["vgui_elements"]["functions"]["dlabel"]["createFunc"] = function(un
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dlabel"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dlabel"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlistview.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dlistview.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dlistview"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DListView",parent)
     pnlData["addColumn"] = nil --otherwise it will get added twice
     pnlData["addLine"] = nil --otherwise it will get added twice
@@ -10,7 +10,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["createFunc"] = function
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     function panel:OnRowSelected(lineID,linePnl)
@@ -28,7 +28,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["createFunc"] = function
                         end
                     end
                     net.Start("E2Vgui.TriggerE2")
-                    net.WriteInt(e2EntityID,32)
+                    net.WriteInt(e2_vgui_core_session_id,32)
                     net.WriteInt(uniqueID,32)
                     net.WriteString("DListView")
                     net.WriteTable({
@@ -49,19 +49,19 @@ E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["createFunc"] = function
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dlistview"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dmodelpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dmodelpanel.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DModelPanel",parent)
 
 
@@ -34,7 +34,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["createFunc"] = functi
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     if pnlData["color"] ~= nil then
@@ -43,14 +43,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["createFunc"] = functi
 
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -66,7 +66,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dmodelpanel"]["modifyFunc"] = functi
         panel.LayoutEntity = panel["oldrotate"]
     end
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpanel.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dpanel"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DPanel",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,7 +8,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["createFunc"] = function(un
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     --TODO: do we always want rounded corners ?
@@ -21,20 +21,20 @@ E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["createFunc"] = function(un
 
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
-E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
     if panel["pnlData"]["parentID"] != nil then --TODO:implement e2function setParent()
-        local parentPnl = E2VguiLib.GetPanelByID(panel["pnlData"]["parentID"],e2EntityID)
+        local parentPnl = E2VguiLib.GetPanelByID(panel["pnlData"]["parentID"],e2_vgui_core_session_id)
         if parentPnl != nil then
             panel:SetParent(parentPnl)
         end
@@ -47,7 +47,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dpanel"]["modifyFunc"] = function(un
             draw.RoundedBox(3,0,0,w,h,col)
         end
     end
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpropertysheet.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dpropertysheet.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dpropertysheet"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dpropertysheet"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-	local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dpropertysheet"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+	local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
 	local panel = vgui.Create("DPropertySheet",parent)
 	--remove copy here otherwise we add the last panel twice (because its also in the changes table)
 	pnlData["addsheet"] = nil
@@ -9,25 +9,25 @@ E2VguiPanels["vgui_elements"]["functions"]["dpropertysheet"]["createFunc"] = fun
 	table.Merge(pnlData,data)
 	--notify server of removal and also update client table
 	function panel:OnRemove()
-		E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+		E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
 	end
 	--TODO: Add color hook to make it colorable
 	panel["uniqueID"] = uniqueID
 	panel["pnlData"] = pnlData
-	E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-	E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+	E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+	E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
 	return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dpropertysheet"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-	local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dpropertysheet"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+	local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
 	if panel == nil or not IsValid(panel)  then return end
 
 	local data = E2VguiLib.applyAttributes(panel,changes)
 	table.Merge(panel["pnlData"],data)
 
-	E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+	E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
 	return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dslider.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dslider.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dslider"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dslider"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-	local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dslider"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+	local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
 	local panel = vgui.Create("DNumSlider",parent)
 	E2VguiLib.applyAttributes(panel,pnlData,true)
 	local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,7 +8,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dslider"]["createFunc"] = function(u
 
 	--notify server of removal and also update client table
 	function panel:OnRemove()
-		E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+		E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
 	end
 	panel["changed"] = true
 
@@ -18,7 +18,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dslider"]["createFunc"] = function(u
 				local uniqueID = self["uniqueID"]
 				if uniqueID != nil then
 					net.Start("E2Vgui.TriggerE2")
-						net.WriteInt(e2EntityID,32)
+						net.WriteInt(e2_vgui_core_session_id,32)
 						net.WriteInt(uniqueID,32)
 						net.WriteString("DSlider")
 						net.WriteTable({
@@ -45,13 +45,13 @@ E2VguiPanels["vgui_elements"]["functions"]["dslider"]["createFunc"] = function(u
 
 	panel["uniqueID"] = uniqueID
 	panel["pnlData"] = pnlData
-	E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-	E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+	E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+	E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
 	return true
 end
 
-E2VguiPanels["vgui_elements"]["functions"]["dslider"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-	local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dslider"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+	local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
 	if panel == nil or not IsValid(panel)  then return end
 
 	local data = E2VguiLib.applyAttributes(panel,changes)
@@ -63,7 +63,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dslider"]["modifyFunc"] = function(u
 			surface.DrawRect(0,0,w,h)
 		end
 	end
-	E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+	E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
 	return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dspawnIcon.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dspawnIcon.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("SpawnIcon",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,14 +8,14 @@ E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"]["createFunc"] = functio
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
 
     function panel:DoClick()
         local uniqueID = self["uniqueID"]
         if uniqueID != nil then
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("dspawnicon")
                 net.WriteTable({
@@ -26,20 +26,20 @@ E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"]["createFunc"] = functio
     end
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dspawnicon"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/client/dtextentry.lua
@@ -1,6 +1,6 @@
 E2VguiPanels["vgui_elements"]["functions"]["dtextentry"] = {}
-E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["createFunc"] = function(uniqueID, pnlData, e2EntityID,changes)
-    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["createFunc"] = function(uniqueID, pnlData, e2_vgui_core_session_id,changes)
+    local parent = E2VguiLib.GetPanelByID(pnlData["parentID"],e2_vgui_core_session_id)
     local panel = vgui.Create("DTextEntry",parent)
     E2VguiLib.applyAttributes(panel,pnlData,true)
     local data = E2VguiLib.applyAttributes(panel,changes)
@@ -8,7 +8,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["createFunc"] = functio
 
     --notify server of removal and also update client table
     function panel:OnRemove()
-        E2VguiLib.RemovePanelWithChilds(self,e2EntityID)
+        E2VguiLib.RemovePanelWithChilds(self,e2_vgui_core_session_id)
     end
     function panel:OnGetFocus()
         --we try to go up the parents to find the DFrame so we can request keyboardinput again
@@ -28,7 +28,7 @@ E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["createFunc"] = functio
         local uniqueID = self["uniqueID"]
         if uniqueID != nil then
             net.Start("E2Vgui.TriggerE2")
-                net.WriteInt(e2EntityID,32)
+                net.WriteInt(e2_vgui_core_session_id,32)
                 net.WriteInt(uniqueID,32)
                 net.WriteString("DTextEntry")
                 net.WriteTable({
@@ -53,20 +53,20 @@ E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["createFunc"] = functio
 
     panel["uniqueID"] = uniqueID
     panel["pnlData"] = pnlData
-    E2VguiLib.RegisterNewPanel(e2EntityID ,uniqueID, panel)
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.RegisterNewPanel(e2_vgui_core_session_id ,uniqueID, panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 
 
-E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["modifyFunc"] = function(uniqueID, e2EntityID, changes)
-    local panel = E2VguiLib.GetPanelByID(uniqueID,e2EntityID)
+E2VguiPanels["vgui_elements"]["functions"]["dtextentry"]["modifyFunc"] = function(uniqueID, e2_vgui_core_session_id, changes)
+    local panel = E2VguiLib.GetPanelByID(uniqueID,e2_vgui_core_session_id)
     if panel == nil or not IsValid(panel)  then return end
 
     local data = E2VguiLib.applyAttributes(panel,changes)
     table.Merge(panel["pnlData"],data)
 
-    E2VguiLib.UpdatePosAndSizeServer(e2EntityID,uniqueID,panel)
+    E2VguiLib.UpdatePosAndSizeServer(e2_vgui_core_session_id,uniqueID,panel)
     return true
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dbutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dbutton.lua
@@ -111,8 +111,8 @@ end
 __e2setcost(5)
 e2function dbutton dbutton(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -123,8 +123,8 @@ end
 
 e2function dbutton dbutton(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -201,7 +201,7 @@ end
                                 getter
 ------------------------------------------------------------------]]--
     e2function vector dbutton:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -209,7 +209,7 @@ end
     end
 
     e2function vector4 dbutton:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {100,100,100,255}
         end
@@ -217,9 +217,9 @@ end
     end
 
     e2function string dbutton:getText(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"text") or ""
     end
 
     e2function number dbutton:getEnabled(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"enabled") and 1 or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"enabled") and 1 or 0
     end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckbox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckbox.lua
@@ -107,8 +107,8 @@ end
 
 e2function dcheckbox dcheckbox(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -119,8 +119,8 @@ end
 
 e2function dcheckbox dcheckbox(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -138,7 +138,7 @@ end
 
 do--[[getter]]--
     e2function number dcheckbox:getChecked(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"checked") and 1 or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"checked") and 1 or 0
     end
 -- getter
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckboxlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckboxlabel.lua
@@ -109,8 +109,8 @@ end
 
 e2function dcheckboxlabel dcheckboxlabel(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -121,8 +121,8 @@ end
 
 e2function dcheckboxlabel dcheckboxlabel(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -148,15 +148,15 @@ end
 
 do--[[getter]]--
     e2function number dcheckboxlabel:getText(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text")
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"text")
     end
 
     e2function number dcheckboxlabel:getChecked(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"checked") and 1 or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"checked") and 1 or 0
     end
 
     e2function number dcheckboxlabel:getIndent(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"indent") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"indent") or 0
     end
 -- getter
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcolormixer.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcolormixer.lua
@@ -111,8 +111,8 @@ end
 
 e2function dcolormixer dcolormixer(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -123,8 +123,8 @@ end
 
 e2function dcolormixer dcolormixer(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -175,7 +175,7 @@ end
 
 do--[[getter]]--
     e2function vector dcolormixer:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -183,7 +183,7 @@ do--[[getter]]--
     end
 
     e2function vector4 dcolormixer:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0,255}
         end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcombobox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcombobox.lua
@@ -109,8 +109,8 @@ end
 ---------------------------------------------------------------------------]]
 e2function dcombobox dcombobox(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -121,8 +121,8 @@ end
 
 e2function dcombobox dcombobox(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -208,15 +208,15 @@ end
 
 do--[[getter]]--
     e2function string dcombobox:getValue(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"value") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"value") or ""
     end
 
     e2function string dcombobox:getValueID(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"valueid") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"valueid") or ""
     end
 
     e2function string dcombobox:getData(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"data") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"data") or ""
     end
 -- getter
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/defaultdermafunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/defaultdermafunctions.lua
@@ -31,8 +31,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
                         if not E2VguiCore.IsPanelInitialised(panel) then return nil end
 
                         local players = {self.player}
-                        if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-                            players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+                        if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+                            players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
                         end
                         return {
                             ["players"] =  players,
@@ -91,8 +91,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local ply = op2[1](self,op2)
 
             return {
-                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"posX") or 0,
-                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"posY") or 0
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"posX") or 0,
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"posY") or 0
             }
         end
         ,5)
@@ -140,8 +140,8 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local ply = op2[1](self,op2)
 
             return {
-                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"width") or 0,
-                panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"height") or 0
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"width") or 0,
+                panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"height") or 0
             }
         end
         ,5)
@@ -170,7 +170,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"width") or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"width") or 0
         end
         ,5)
 
@@ -198,7 +198,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"height") or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"height") or 0
         end
         ,5)
 
@@ -244,7 +244,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
 
             if not panel then return end -- may be nil
 
-            return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"minSize") or {0, 0}
+            return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"minSize") or {0, 0}
         end
         ,5)
 
@@ -271,7 +271,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),panel,"visible") and 1 or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,panel,"visible") and 1 or 0
         end
         ,5)
 
@@ -433,7 +433,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             local panel = op1[1](self,op1)
             local ply = op2[1](self,op2)
 
-            return panel and E2VguiCore.GetPanelAttribute(ply, self.entity:EntIndex(), panel, "noClipping") and 1 or 0
+            return panel and E2VguiCore.GetPanelAttribute(ply, self.entity.e2_vgui_core_session_id, panel, "noClipping") and 1 or 0
         end
         ,5)
 
@@ -503,7 +503,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             if not panel then return end -- may be nil
 
             if IsValid(ply) and ply:IsPlayer() then
-                E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
+                E2VguiCore.RemovePanel(self.entity.e2_vgui_core_session_id,panel["paneldata"]["uniqueID"],ply)
             end
         end
         ,5)
@@ -517,7 +517,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             if not panel then return end -- may be nil
 
             for _,ply in pairs(panel["players"]) do
-                E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
+                E2VguiCore.RemovePanel(self.entity.e2_vgui_core_session_id,panel["paneldata"]["uniqueID"],ply)
             end
         end
         ,5)
@@ -580,7 +580,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
                         panel["players"][key] = nil
                     end
                 end
-                E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
+                E2VguiCore.RemovePanel(self.entity.e2_vgui_core_session_id,panel["paneldata"]["uniqueID"],ply)
             end
         end
         ,5)
@@ -594,7 +594,7 @@ E2VguiCore.registerCallback("loaded_elements",function()
             if not panel then return end -- may be nil
 
             for _,ply in pairs(panel["players"]) do
-                E2VguiCore.RemovePanel(self.entity:EntIndex(),panel["paneldata"]["uniqueID"],ply)
+                E2VguiCore.RemovePanel(self.entity.e2_vgui_core_session_id,panel["paneldata"]["uniqueID"],ply)
             end
             panel["players"] = {}
         end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dframe.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dframe.lua
@@ -114,8 +114,8 @@ end
 ---------------------------------------------------------------------------]]
 e2function dframe dframe(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -194,7 +194,7 @@ end
 
 do--[[getter]]--
     e2function vector dframe:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -202,7 +202,7 @@ do--[[getter]]--
     end
 
     e2function vector4 dframe:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0,255}
         end
@@ -210,27 +210,27 @@ do--[[getter]]--
     end
 
     e2function string dframe:getTitle(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"title") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"title") or ""
     end
 
     e2function number dframe:getSizable(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"sizable") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"sizable") or 0
     end
 
     e2function vector2 dframe:getMinWidth(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply, self.entity:EntIndex(), this, "minWidth") or 0
+        return E2VguiCore.GetPanelAttribute(ply, self.entity.e2_vgui_core_session_id, this, "minWidth") or 0
     end
 
     e2function vector2 dframe:getMinHeight(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply, self.entity:EntIndex(), this, "minHeight") or 0
+        return E2VguiCore.GetPanelAttribute(ply, self.entity.e2_vgui_core_session_id, this, "minHeight") or 0
     end
 
     e2function number dframe:getShowCloseButton(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"showCloseButton") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"showCloseButton") or 0
     end
 
     e2function number dframe:getDeleteOnClose(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"deleteOnClose") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"deleteOnClose") or 0
     end
 -- getter
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dimagebutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dimagebutton.lua
@@ -114,8 +114,8 @@ end
 __e2setcost(5)
 e2function dimagebutton dimagebutton(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -126,8 +126,8 @@ end
 
 e2function dimagebutton dimagebutton(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -214,7 +214,7 @@ end
                                 getter
 ------------------------------------------------------------------]]--
     e2function vector dimagebutton:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -222,7 +222,7 @@ end
     end
 
     e2function vector4 dimagebutton:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {100,100,100,255}
         end
@@ -230,13 +230,13 @@ end
     end
 
     e2function string dimagebutton:getText(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"text") or ""
     end
 
     e2function number dimagebutton:getEnabled(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"enabled") and 1 or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"enabled") and 1 or 0
     end
 
     e2function string dimagebutton:getImage(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"image") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"image") or ""
     end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlabel.lua
@@ -110,8 +110,8 @@ end
 
 e2function dlabel dlabel(number uniqueID)
 	local players = {self.player}
-	if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-		players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+	if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+		players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
 	end
 	return {
 		["players"] =  players,
@@ -122,8 +122,8 @@ end
 
 e2function dlabel dlabel(number uniqueID,number parentID)
 	local players = {self.player}
-	if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-		players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+	if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+		players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
 	end
 	return {
 		["players"] =  players,
@@ -191,7 +191,7 @@ end
 
 do--[[getter]]--
 	e2function vector dlabel:getColor(entity ply)
-		local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+		local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
 		if col == nil then
 			return {0,0,0}
 		end
@@ -199,7 +199,7 @@ do--[[getter]]--
 	end
 
 	e2function vector4 dlabel:getColor4(entity ply)
-		local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+		local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
 		if col == nil then
 			return {0,0,0,255}
 		end
@@ -207,7 +207,7 @@ do--[[getter]]--
 	end
 
 	e2function string dlabel:getText(entity ply)
-		return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text") or ""
+		return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"text") or ""
 	end
 
 -- getter

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
@@ -108,8 +108,8 @@ end
 
 e2function dlistview dlistview(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -120,8 +120,8 @@ end
 
 e2function dlistview dlistview(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -166,11 +166,11 @@ end
 
 do--[[getter]]--
     e2function number dlistview:getIndex(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"index") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"index") or 0
     end
 
     e2function table dlistview:getValues(entity ply)
-        local values = E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"values")
+        local values = E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"values")
         if values ~= nil and istable(values) then
             local table = E2VguiCore.convertToE2Table(values)
             return table

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dmodelpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dmodelpanel.lua
@@ -111,8 +111,8 @@ end
 ---------------------------------------------------------------------------]]
 e2function dmodelpanel dmodelpanel(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -123,8 +123,8 @@ end
 
 e2function dmodelpanel dmodelpanel(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -218,7 +218,7 @@ end
 
 do--[[getter]]--
     e2function vector dmodelpanel:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -226,7 +226,7 @@ do--[[getter]]--
     end
 
     e2function vector4 dmodelpanel:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0,255}
         end
@@ -234,7 +234,7 @@ do--[[getter]]--
     end
 
     e2function string dmodelpanel:getModel(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"model") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"model") or ""
     end
 -- getter
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpanel.lua
@@ -109,8 +109,8 @@ end
 ---------------------------------------------------------------------------]]
 e2function dpanel dpanel(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -121,8 +121,8 @@ end
 
 e2function dpanel dpanel(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -160,7 +160,7 @@ end
 
 do--[[getter]]--
     e2function vector dpanel:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -168,7 +168,7 @@ do--[[getter]]--
     end
 
     e2function vector4 dpanel:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0,255}
         end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
@@ -126,7 +126,12 @@ do--[[setter]]--
     end
 
     e2function void dpropertysheet:addSheet(string name,xdp panel,string icon)
-        E2VguiCore.registerAttributeChange(this,"addsheet",{["name"] = name, ["panelID"] = panel["paneldata"]["uniqueID"], ["icon"] = icon, ["e2EntityID"] = self.entity.e2_vgui_core_session_id })
+        E2VguiCore.registerAttributeChange(this,"addsheet",{
+            ["name"] = name, 
+            ["panelID"] = panel["paneldata"]["uniqueID"], 
+            ["icon"] = icon, 
+            ["e2_vgui_core_session_id"] = self.entity.e2_vgui_core_session_id 
+        })
     end
 
     e2function void dpropertysheet:closeTab(string name)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
@@ -109,8 +109,8 @@ end
 
 e2function dpropertysheet dpropertysheet(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -121,8 +121,8 @@ end
 
 e2function dpropertysheet dpropertysheet(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -153,7 +153,7 @@ do--[[setter]]--
     end
 
     e2function void dpropertysheet:addSheet(string name,xdp panel,string icon)
-        E2VguiCore.registerAttributeChange(this,"addsheet",{["name"] = name, ["panelID"] = panel["paneldata"]["uniqueID"], ["icon"] = icon, ["e2EntityID"] = self.entity:EntIndex() })
+        E2VguiCore.registerAttributeChange(this,"addsheet",{["name"] = name, ["panelID"] = panel["paneldata"]["uniqueID"], ["icon"] = icon, ["e2EntityID"] = self.entity.e2_vgui_core_session_id })
     end
 
     e2function void dpropertysheet:closeTab(string name)
@@ -164,7 +164,7 @@ end
 
 do--[[getter]]--
     e2function vector dpropertysheet:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -172,7 +172,7 @@ do--[[getter]]--
     end
 
     e2function vector4 dpropertysheet:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0,255}
         end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dslider.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dslider.lua
@@ -112,8 +112,8 @@ end
 ---------------------------------------------------------------------------]]
 e2function dslider dslider(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -124,8 +124,8 @@ end
 
 e2function dslider dslider(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -183,7 +183,7 @@ end
 
 do--[[getter]]--
     e2function vector dslider:getColor(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0}
         end
@@ -191,7 +191,7 @@ do--[[getter]]--
     end
 
     e2function vector4 dslider:getColor4(entity ply)
-        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"color")
+        local col =  E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"color")
         if col == nil then
             return {0,0,0,255}
         end
@@ -199,15 +199,15 @@ do--[[getter]]--
     end
 
     e2function number dslider:getValue(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"value") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"value") or 0
     end
 
     e2function number dslider:getMin(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"min") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"min") or 0
     end
 
     e2function number dslider:getMax(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"max") or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"max") or 0
     end
 
 -- getter

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dspawnicon.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dspawnicon.lua
@@ -107,8 +107,8 @@ __e2setcost(5)
 
 e2function dspawnicon dspawnicon(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -119,8 +119,8 @@ end
 
 e2function dspawnicon dspawnicon(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -147,9 +147,9 @@ e2function void dspawnicon:setModel(string model)
                                 getter
 ------------------------------------------------------------------]]--
     e2function number dspawnicon:getEnabled(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"enabled") and 1 or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"enabled") and 1 or 0
     end
 
     e2function string dspawnicon:getModel(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"model") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"model") or ""
     end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
@@ -107,8 +107,8 @@ end
 
 e2function dtextentry dtextentry(number uniqueID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -119,8 +119,8 @@ end
 
 e2function dtextentry dtextentry(number uniqueID,number parentID)
     local players = {self.player}
-    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] != nil then
-        players = self.entity.e2_vgui_core_default_players[self.entity:EntIndex()]
+    if self.entity.e2_vgui_core_default_players != nil and self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] != nil then
+        players = self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id]
     end
     return {
         ["players"] =  players,
@@ -142,11 +142,11 @@ end
 
 do--[[getter]]--
     e2function string dtextentry:getText(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"text") or ""
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"text") or ""
     end
 
     e2function number dtextentry:getNumeric(entity ply)
-        return E2VguiCore.GetPanelAttribute(ply,self.entity:EntIndex(),this,"numeric") and 1 or 0
+        return E2VguiCore.GetPanelAttribute(ply,self.entity.e2_vgui_core_session_id,this,"numeric") and 1 or 0
     end
 -- getter
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dutilities.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dutilities.lua
@@ -18,12 +18,12 @@ e2function number vguiCanSend()
 end
 
 e2function void vguiCloseAll()
-    E2VguiCore.RemoveAllPanelsOfE2(self.entity:EntIndex())
+    E2VguiCore.RemoveAllPanelsOfE2(self.entity.e2_vgui_core_session_id)
 end
 
 e2function void vguiCloseOnPlayer(entity ply)
     if ply == nil or not ply:IsPlayer() then return end
-    E2VguiCore.RemovePanelsOnPlayer(self.entity:EntIndex(),ply)
+    E2VguiCore.RemovePanelsOnPlayer(self.entity.e2_vgui_core_session_id,ply)
 end
 
 e2function void vguiDefaultPlayers(array players)
@@ -31,49 +31,49 @@ e2function void vguiDefaultPlayers(array players)
     if self.entity.e2_vgui_core_default_players == nil then
         self.entity.e2_vgui_core_default_players = {}
     end
-    if self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] == nil then
-        self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] = {}
+    if self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] == nil then
+        self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] = {}
     end
-    self.entity.e2_vgui_core_default_players[self.entity:EntIndex()] = E2VguiCore.FilterPlayers(players)
+    self.entity.e2_vgui_core_default_players[self.entity.e2_vgui_core_session_id] = E2VguiCore.FilterPlayers(players)
 end
 
 --[[-------------------------------------------------------------------------
             RunOnVGUI stuff, used for button clicks and similar
 -------------------------------------------------------------------------]]--
 e2function void runOnVgui(number enabled)
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then
-        E2VguiCore.Trigger[self.entity:EntIndex()] = {}
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then
+        E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] = {}
     end
-    E2VguiCore.Trigger[self.entity:EntIndex()].RunOnDerma = (enabled >= 1)
+    E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].RunOnDerma = (enabled >= 1)
 end
 
 e2function number vguiClk()
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then return 0 end
-    return E2VguiCore.Trigger[self.entity:EntIndex()].run and 1 or 0
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then return 0 end
+    return E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].run and 1 or 0
 end
 
 e2function number vguiClk(entity ply)
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then return 0 end
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then return 0 end
     if ply == nil or not ply:IsPlayer() then return 0 end
-    return (E2VguiCore.Trigger[self.entity:EntIndex()].triggeredByClient == ply) and 1 or 0
+    return (E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].triggeredByClient == ply) and 1 or 0
 end
 
 e2function number vguiClkPanelID()
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then return -1 end
-    return E2VguiCore.Trigger[self.entity:EntIndex()].triggerUniqueID or -1
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then return -1 end
+    return E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].triggerUniqueID or -1
 end
 
 e2function entity vguiClkPlayer()
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then return NULL end
-    return  E2VguiCore.Trigger[self.entity:EntIndex()].triggeredByClient or NULL
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then return NULL end
+    return  E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].triggeredByClient or NULL
 end
 
 e2function array vguiClkValues()
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then return {} end
-    return E2VguiCore.Trigger[self.entity:EntIndex()].triggerValues
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then return {} end
+    return E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].triggerValues
 end
 
 e2function table vguiClkValuesTable()
-    if E2VguiCore.Trigger[self.entity:EntIndex()] == nil then return {n={},ntypes={},s={},stypes={},size=0} end
-    return E2VguiCore.Trigger[self.entity:EntIndex()].triggerValuesTable
+    if E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id] == nil then return {n={},ntypes={},s={},stypes={},size=0} end
+    return E2VguiCore.Trigger[self.entity.e2_vgui_core_session_id].triggerValuesTable
 end


### PR DESCRIPTION
This should fix #20  the reload bug.
We use a newly generated ID everytime we reload the E2 instead of the EntityID which caused problems with persistent panels.

TODO:

- [x] Make sure vehicle linking works
- [x] Test in multiplayer
- [x] TODOs in Code