### PR TITLE
Update for latest E2 API

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/load_vgui_elements.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/load_vgui_elements.lua
@@ -26,7 +26,7 @@ end
 
 -- parses and executes an extension
 local function e2_include_pass2(name, luaname, contents)
-    local ok, ret = pcall(E2Lib.ExtPP.Pass2, contents)
+    local ok, ret = pcall(E2Lib.ExtPP.Pass2, contents, luaname)
     if not ok then
         WireLib.ErrorNoHalt(luaname .. ret .. "\n")
         return

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dbutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dbutton.lua
@@ -55,11 +55,6 @@ e2function number operator_is(xdb pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdb pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdb ldata, xdb rdata)
@@ -78,28 +73,6 @@ end
 e2function number operator==(n index,xdb rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdb ldata, xdb rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdb ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdb rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckbox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckbox.lua
@@ -51,11 +51,6 @@ e2function number operator_is(xdc pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdc pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdc ldata, xdc rdata)
@@ -74,28 +69,6 @@ end
 e2function number operator==(n index,xdc rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdc ldata, xdc rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdc ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdc rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckboxlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcheckboxlabel.lua
@@ -53,11 +53,6 @@ e2function number operator_is(xbl pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xbl pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xbl ldata, xbl rdata)
@@ -76,28 +71,6 @@ end
 e2function number operator==(n index,xbl rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xbl ldata, xbl rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xbl ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xbl rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcolormixer.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcolormixer.lua
@@ -55,11 +55,6 @@ e2function number operator_is(xde pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xde pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xde ldata, xde rdata)
@@ -78,28 +73,6 @@ end
 e2function number operator==(n index,xde rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xde ldata, xde rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xde ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xde rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcombobox.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dcombobox.lua
@@ -55,11 +55,6 @@ e2function number operator_is(xcb pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xcb pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xcb ldata, xcb rdata)
@@ -78,28 +73,6 @@ end
 e2function number operator==(n index,xcb rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xcb ldata, xcb rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xcb ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xcb rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dframe.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dframe.lua
@@ -59,11 +59,6 @@ e2function number operator_is(xdf pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdf pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdf ldata, xdf rdata)
@@ -83,28 +78,6 @@ end
 e2function number operator==(n index,xdf rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
-
---- B != B
---TODO:
-e2function number operator!=(xdf ldata, xdf rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdf ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdf rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dimagebutton.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dimagebutton.lua
@@ -58,11 +58,6 @@ e2function number operator_is(xib pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xib pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xib ldata, xib rdata)
@@ -81,28 +76,6 @@ end
 e2function number operator==(n index,xib rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xib ldata, xib rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xib ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xib rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlabel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlabel.lua
@@ -54,11 +54,6 @@ e2function number operator_is(xdl pnldata)
 	return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdl pnldata)
-	return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdl ldata, xdl rdata)
@@ -77,28 +72,6 @@ end
 e2function number operator==(n index,xdl rdata)
 	if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
 	return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdl ldata, xdl rdata)
-	if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-	if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-	return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdl ldata, n index)
-	if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-	return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdl rdata)
-	if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-	return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
@@ -119,18 +119,16 @@ do--[[setter]]--
         E2VguiCore.registerAttributeChange(this,"addColumn", {["column"] = column, ["columnWidth"] = width, ["position"] = position})
     end
 
-    if SERVER then
-        e2function void dlistview:addLine(...args)
-            local line = {}
-            for k,v in pairs(args) do
-                if type(v) == "string" or type(v) == "number" then --only allow strings and numbers
-                    line[#line+1] = v
-                else
-                    line[#line+1] = ""
-                end
+    e2function void dlistview:addLine(...args)
+        local line = {}
+        for k,v in pairs(args) do
+            if type(v) == "string" or type(v) == "number" then --only allow strings and numbers
+                line[#line+1] = v
+            else
+                line[#line+1] = ""
             end
-            E2VguiCore.registerAttributeChange(this,"addLine", {unpack(line)})
         end
+        E2VguiCore.registerAttributeChange(this,"addLine", {unpack(line)})
     end
 
     e2function void dlistview:setMultiSelect(number multiselect)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dlistview.lua
@@ -52,11 +52,6 @@ e2function number operator_is(xdv pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdv pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdv ldata, xdv rdata)
@@ -75,28 +70,6 @@ end
 e2function number operator==(n index,xdv rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdv ldata, xdv rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdv ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdv rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------
@@ -146,16 +119,18 @@ do--[[setter]]--
         E2VguiCore.registerAttributeChange(this,"addColumn", {["column"] = column, ["columnWidth"] = width, ["position"] = position})
     end
 
-    e2function void dlistview:addLine(...)
-        local line = {}
-        for k,v in pairs({...}) do
-            if type(v) == "string" or type(v) == "number" then --only allow strings and numbers
-                line[#line+1] = v
-            else
-                line[#line+1] = ""
+    if SERVER then
+        e2function void dlistview:addLine(...args)
+            local line = {}
+            for k,v in pairs(args) do
+                if type(v) == "string" or type(v) == "number" then --only allow strings and numbers
+                    line[#line+1] = v
+                else
+                    line[#line+1] = ""
+                end
             end
+            E2VguiCore.registerAttributeChange(this,"addLine", {unpack(line)})
         end
-        E2VguiCore.registerAttributeChange(this,"addLine", {unpack(line)})
     end
 
     e2function void dlistview:setMultiSelect(number multiselect)

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dmodelpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dmodelpanel.lua
@@ -56,11 +56,6 @@ e2function number operator_is(xdk pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdk pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdk ldata, xdk rdata)
@@ -80,28 +75,6 @@ end
 e2function number operator==(n index,xdk rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
-
---- B != B
---TODO:
-e2function number operator!=(xdk ldata, xdk rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdk ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdk rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpanel.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpanel.lua
@@ -54,11 +54,6 @@ e2function number operator_is(xdp pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdp pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO:
 e2function number operator==(xdp ldata, xdp rdata)
@@ -78,28 +73,6 @@ end
 e2function number operator==(n index,xdp rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO:
-e2function number operator!=(xdp ldata, xdp rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdp ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdp rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dpropertysheet.lua
@@ -53,11 +53,6 @@ e2function number operator_is(xdo pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdo pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdo ldata, xdo rdata)
@@ -76,28 +71,6 @@ end
 e2function number operator==(n index,xdo rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdo ldata, xdo rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdo ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdo rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dslider.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dslider.lua
@@ -58,11 +58,6 @@ e2function number operator_is(xds pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xds pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xds ldata, xds rdata)
@@ -82,28 +77,6 @@ e2function number operator==(n index,xds rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
 end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xds ldata, xds rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xds ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xds rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
 
 --[[-------------------------------------------------------------------------
     Desc: Creates a DSlider element

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dspawnicon.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dspawnicon.lua
@@ -50,11 +50,6 @@ e2function number operator_is(xdi pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdi pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdi ldata, xdi rdata)
@@ -73,28 +68,6 @@ end
 e2function number operator==(n index,xdi rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdi ldata, xdi rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdi ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdi rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------

--- a/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/vgui_elements/server/dtextentry.lua
@@ -51,11 +51,6 @@ e2function number operator_is(xdt pnldata)
     return E2VguiCore.IsPanelInitialised(pnldata) and  1 or 0
 end
 
--- if (!B)
-e2function number operator!(xdt pnldata)
-    return E2VguiCore.IsPanelInitialised(pnldata) and  0 or 1
-end
-
 --- B == B --check if the names match
 --TODO: Check if the entire pnl data is equal (each attribute of the panel)
 e2function number operator==(xdt ldata, xdt rdata)
@@ -74,28 +69,6 @@ end
 e2function number operator==(n index,xdt rdata)
     if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
     return rdata["paneldata"]["uniqueID"] == index and 1 or 0
-end
-
-
---- B != B
---TODO: Check if the entire pnl data is equal (each attribute of the panel)
-e2function number operator!=(xdt ldata, xdt rdata)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 1 end
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 1 end
-    return ldata["paneldata"]["uniqueID"] == rdata["paneldata"]["uniqueID"] and 0 or 1
-end
-
-
---- B != number --check if the uniqueID matches
-e2function number operator!=(xdt ldata, n index)
-    if not E2VguiCore.IsPanelInitialised(ldata) then return 0 end
-    return ldata["paneldata"]["uniqueID"] == index and 0 or 1
-end
-
---- number != B --check if the uniqueID matches
-e2function number operator!=(n index,xdt rdata)
-    if not E2VguiCore.IsPanelInitialised(rdata) then return 0 end
-    return rdata["paneldata"]["uniqueID"] == index and 0 or 1
 end
 
 --[[-------------------------------------------------------------------------


### PR DESCRIPTION
- Added filename argument to preprocessor
- Uses named varargs instead of Lua varargs (+`if SERVER` because this file is included CS?)
- Removes `!` operator definitions
- Removes `!=` operator definitions

Fixes https://github.com/wiremod/wire/issues/2912